### PR TITLE
Recreate loader if old loader is on incorrect loop

### DIFF
--- a/graphene_sqlalchemy/batching.py
+++ b/graphene_sqlalchemy/batching.py
@@ -137,9 +137,8 @@ def get_batch_resolver(relationship_prop):
             RELATIONSHIP_LOADERS_CACHE[relationship_prop] = loader
         return loader
 
-    loader = _get_loader(relationship_prop)
 
     async def resolve(root, info, **args):
-        return await loader.load(root)
+        return await _get_loader(relationship_prop).load(root)
 
     return resolve

--- a/graphene_sqlalchemy/batching.py
+++ b/graphene_sqlalchemy/batching.py
@@ -137,7 +137,6 @@ def get_batch_resolver(relationship_prop):
             RELATIONSHIP_LOADERS_CACHE[relationship_prop] = loader
         return loader
 
-
     async def resolve(root, info, **args):
         return await _get_loader(relationship_prop).load(root)
 

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -26,7 +26,6 @@ from graphene_sqlalchemy.tests.utils import wrap_select_func
 from graphene_sqlalchemy.utils import SQL_VERSION_HIGHER_EQUAL_THAN_1_4, SQL_VERSION_HIGHER_EQUAL_THAN_2
 
 # fmt: off
-import sqlalchemy
 if SQL_VERSION_HIGHER_EQUAL_THAN_2:
     from sqlalchemy.sql.sqltypes import HasExpressionLookup # noqa  # isort:skip
 else:


### PR DESCRIPTION
Related to https://github.com/AsimovBio/kernel-backend/issues/1188

This change makes it so that the batched data loader is recreated at field resolution time if the current event loop is different than the event loop for the loader.

Previously, the loaders were only created at GraphQL `Schema` creation time. In many systems (including FastAPI and Starlette's `TestClient`), the `Schema` object is required in order to initiate the mount of the GraphQL routes. Thereafter, a new event loop is created (owned by the request handler).

This means that, almost by definition, in many frameworks the initial loaders _will_ be created on one event loop and used on a different event loop in the future. To resolve this problem, I make it so that we only use the memoized loader _if it was created on the same event loop as where the resolution is happening_.